### PR TITLE
Add script to find top dependents

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+- package-ecosystem: pip
+  directory: "/"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 10
+  allow:
+  - dependency-type: direct
+  - dependency-type: indirect
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 10

--- a/.github/workflows/dependents-report.yml
+++ b/.github/workflows/dependents-report.yml
@@ -1,0 +1,32 @@
+name: Generate top dependents report
+on:
+  schedule:
+    - cron: '0 14 * * 1'
+jobs:
+  create-dependents-report:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
+      - name: Set up Python
+        uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+          cache-dependency-path: 'dependents-report/requirements.txt'
+      - name: Run script
+        run: python dependents-report/get-dependents.py
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create PR
+        uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38
+        with:
+          commit-message: Regenerate dependents report
+          title: Regenerate dependents report
+          body: This PR updates the dependents report.
+          base: main
+          branch: actions-regenerate-dependents-report
+          delete-branch: true
+          signoff: true
+          author: GitHub <noreply@github.com>
+          committer: GitHub <noreply@github.com>

--- a/dependents-report/README.md
+++ b/dependents-report/README.md
@@ -1,0 +1,57 @@
+
+# Top Dependents
+
+This file lists the top 50 dependents of in-toto-golang sorted by GitHub stars.
+
+| Repository | Stars |
+|------------|-------|
+| docker/compose | 30335 |
+| aquasecurity/trivy | 18449 |
+| gravitational/teleport | 14988 |
+| earthly/earthly | 9486 |
+| dagger/dagger | 8933 |
+| kubescape/kubescape | 8813 |
+| linuxkit/linuxkit | 7910 |
+| redpanda-data/redpanda | 7634 |
+| moby/buildkit | 7008 |
+| kyverno/kyverno | 4322 |
+| sigstore/cosign | 3576 |
+| docker/buildx | 2811 |
+| testcontainers/testcontainers-go | 2396 |
+| DataDog/datadog-agent | 2298 |
+| ddworken/hishtory | 2048 |
+| spiffe/spire | 1484 |
+| grafeas/grafeas | 1458 |
+| lunasec-io/lunasec | 1344 |
+| getporter/porter | 1044 |
+| acorn-io/runtime | 1042 |
+| openclarity/kubeclarity | 1041 |
+| stackrox/stackrox | 1031 |
+| guacsec/guac | 1013 |
+| controlplaneio/kubesec | 1003 |
+| buildpacks-community/kpack | 854 |
+| sigstore/gitsign | 828 |
+| sigstore/rekor | 761 |
+| defenseunicorns/zarf | 683 |
+| aquasecurity/trivy-operator | 673 |
+| kubernetes-sigs/cluster-api-provider-aws | 576 |
+| kubernetes-sigs/security-profiles-operator | 566 |
+| project-zot/zot | 467 |
+| kubernetes/release | 451 |
+| paultyng/terraform-provider-unifi | 449 |
+| tektoncd/cli | 398 |
+| tektoncd/operator | 367 |
+| project-copacetic/copacetic | 348 |
+| kubernetes-sigs/kubetest2 | 289 |
+| slsa-framework/slsa-github-generator | 276 |
+| kubernetes-sigs/bom | 255 |
+| tektoncd/chains | 220 |
+| fluxcd/source-controller | 206 |
+| chainloop-dev/chainloop | 199 |
+| flutter/cocoon | 178 |
+| ossf/scorecard-action | 171 |
+| project-stacker/stacker | 149 |
+| gitpod-io/leeway | 145 |
+| deislabs/ratify | 139 |
+| slsa-framework/slsa-verifier | 133 |
+| kubernetes-sigs/promo-tools | 132 |

--- a/dependents-report/get-dependents.py
+++ b/dependents-report/get-dependents.py
@@ -1,0 +1,73 @@
+import json
+import os
+import requests
+import sys
+
+
+API_URL = "https://api.github.com"
+SEARCHED_REPOSITORY = "github.com/in-toto/in-toto-golang"
+
+
+def main():
+    text = """
+# Top Dependents
+
+This file lists the top 50 dependents of in-toto-golang sorted by GitHub stars.
+
+| Repository | Stars |
+|------------|-------|
+"""
+    search_query = f"{SEARCHED_REPOSITORY} filename:go.mod"
+    url = f"{API_URL}/search/code?q={search_query}&per_page=100"
+    print(f"Looking up '{url}'")
+    response = requests.get(
+        url,
+        headers={"authorization": f"Bearer {os.environ['GITHUB_TOKEN']}"},
+    )
+    if response.status_code != 200:
+        sys.exit(1)
+    response_obj = json.loads(response.text)
+
+    items = response_obj["items"]
+
+    total_pages = response_obj["total_count"] // 100 + 1
+    for i in range(2, total_pages + 1):
+        url = f"{API_URL}/search/code?q={search_query}&per_page=100&page={i}"
+        print(f"Looking up '{url}'")
+        response = requests.get(
+            url,
+            headers={"authorization": f"Bearer {os.environ['GITHUB_TOKEN']}"},
+        )
+        if response.status_code != 200:
+            sys.exit(1)
+        items.extend(json.loads(response.text)["items"])
+
+    repositories = {}
+    for item in items:
+        repo_path = item["repository"]["full_name"]
+        url = f"{API_URL}/repos/{repo_path}"
+        print(f"Looking up '{url}'")
+        # TODO: asyncio -> parallelize
+        stars_response = requests.get(
+            f"{API_URL}/repos/{repo_path}",
+            headers={"authorization": f"Bearer {os.environ['GITHUB_TOKEN']}"},
+        )
+        stars_response_obj = json.loads(stars_response.text)
+
+        repositories[repo_path] = stars_response_obj["stargazers_count"]
+    
+    sorted_by_stars = sorted(
+        repositories.items(),
+        key=lambda x: x[1],
+        reverse=True,
+    )[:50]
+
+    for repo, star in sorted_by_stars:
+        text += f"| {repo} | {star} |\n"
+
+    with open("dependents-report/README.md", "w+") as fp:
+        fp.write(text)
+
+
+if __name__ == "__main__":
+    main()

--- a/dependents-report/requirements.txt
+++ b/dependents-report/requirements.txt
@@ -1,0 +1,5 @@
+certifi==2023.7.22
+charset-normalizer==3.2.0
+idna==3.4
+requests==2.31.0
+urllib3==2.0.4


### PR DESCRIPTION
This is based off some excellent work by @SpencerKlem. It uses GitHub API's code search endpoint to identify occurrences of in-toto-golang in go.mod files, looks up the repositories' stars, and lists the top 50.

I've done some reworking of the script to generate a markdown file and create a PR on a weekly basis if the new report is different from the existing one.