### PR TITLE
Fetch requirements for dependents script

### DIFF
--- a/.github/workflows/dependents-report.yml
+++ b/.github/workflows/dependents-report.yml
@@ -14,6 +14,8 @@ jobs:
           python-version: '3.11'
           cache: 'pip'
           cache-dependency-path: 'dependents-report/requirements.txt'
+      - name: Fetch requirements
+        run: python -m pip install -r dependents-report/requirements.txt
       - name: Run script
         run: python dependents-report/get-dependents.py
         env:


### PR DESCRIPTION
Adds missing `pip install` step to fetch requests etc.